### PR TITLE
Set `:logger` backend to `:console` in `test.exs`

### DIFF
--- a/src/main/g8/config/test.exs
+++ b/src/main/g8/config/test.exs
@@ -23,7 +23,7 @@ config :$name$, $name;format="word-space,Camel"$Web.Endpoint,
   server: false
 
 # Print only warnings and errors during test
-config :logger, level: :warn, backends: [:console],
+config :logger, level: :warn, backends: [:console]
 
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime

--- a/src/main/g8/config/test.exs
+++ b/src/main/g8/config/test.exs
@@ -23,7 +23,7 @@ config :$name$, $name;format="word-space,Camel"$Web.Endpoint,
   server: false
 
 # Print only warnings and errors during test
-config :logger, level: :warn
+config :logger, level: :warn, backends: [:console],
 
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime


### PR DESCRIPTION
In `config.exs` the `:logger` configuration is setting its backend as `LoggerJSON`. This should be the backend for `:prod` and `:dev` but in `:test` it's better the backend to be set as `:console`. We don't need to see the logs in `:test`, we just need to assert they are there. By setting the backend as `:console` in `:test` we can assert and clean up the tests using the functions from [`ExUnit.CaptureLog`](https://hexdocs.pm/ex_unit/1.13/ExUnit.CaptureLog.html#capture_log/2).

Reference:
https://github.com/shore-gmbh/customers-service/pull/82

# Goal
- Change the `:logger` backend to `:console` in `test.exs`.