### PR TITLE
Add ecto repo config

### DIFF
--- a/src/main/g8/config/config.exs
+++ b/src/main/g8/config/config.exs
@@ -9,7 +9,15 @@ import Config
 
 $if(include_database.truthy)$
 config :$name$,
-  ecto_repos: [$name;format="word-space,Camel"$.Repo]
+  ecto_repos: [$name;format="word-space,Camel"$.Repo],
+  generators: [binary_id: true]
+$endif$
+
+$if(include_database.truthy)$
+config :$name$, $name;format="word-space,Camel"$.Repo
+  migration_primary_key: [type: :uuid],
+  migration_foreign_key: [type: :uuid],
+  migration_timestamps: [type: :utc_datetime_usec]
 $endif$
 
 # Configures the endpoint

--- a/src/main/g8/lib/$name$/$if(include_database.truthy)$schema.ex$endif$
+++ b/src/main/g8/lib/$name$/$if(include_database.truthy)$schema.ex$endif$
@@ -1,0 +1,13 @@
+defmodule $name;format="word-space,Camel"$.Schema do
+  defmacro __using__(_) do
+    quote do
+      use Ecto.Schema
+
+      import Ecto.Changeset
+
+      @primary_key {:id, Ecto.UUID, autogenerate: true}
+      @foreign_key_type Ecto.UUID
+      @timestamps_opts [type: :utc_datetime_usec]
+    end
+  end
+end


### PR DESCRIPTION
## Goals

1. Configure the migrations in `config.exs` in order to avoid setting the `id` and `timestamps` types per migration.

- `migration_primary_key` and `migration_foreign_key` as `uuid`;
- `migration_timestamps` as `utc_datetime_usec`.

2.  Add a `AppName.Schema` module that can be `use`d in the schema files in order to avoid adding the same configurations per schema.

### Before

```elixir
defmodule AppName.ExampleSchema do
  use Ecto.Schema
  
  # EITHER
  @primary_key {:id, Ecto.UUID, autogenerate: true}
  @timestamps_opts [type: :utc_datetime_usec]

  schema "example_schema" do
    # OR
    field :id, Ecto.UUID, autogenerate: true

    field :name, :string

    # OR
    timestamps(type: :utc_datetime_usec)
  end
end
```

### After
```elixir
defmodule AppName.ExampleSchema do
  use AppName.Schema

  schema "example_schema" do
    field :name, :string

    timestamps()
  end
end
```
