### PR TITLE
Fix credo config file arg in `src/main/g8/.circleci/config.yml`

### DIFF
--- a/src/main/g8/.circleci/config.yml
+++ b/src/main/g8/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
 
       - run:
           name: Run credo
-          command: mix credo -c .credo.exs --strict
+          command: mix credo --config-file .credo.exs --strict
 
       - run:
           name: Run tests


### PR DESCRIPTION
### Why
Credo offences were not breaking in the CI

### Change
Fix the credo file argument in `src/main/g8/.circleci/config.yml`